### PR TITLE
modify diffSnuximModels to present diffs on a single line

### DIFF
--- a/R/Utility-Functions.R
+++ b/R/Utility-Functions.R
@@ -197,7 +197,7 @@ diffSnuximModels <- function(model_old, model_new,
                              full_diff = TRUE,
                              d2_session = dynGet("d2_default_session",
                                                  inherits = TRUE)
-                             ) {
+) {
 
   # only include countries present in both files
   if (full_diff) {
@@ -211,18 +211,29 @@ diffSnuximModels <- function(model_old, model_new,
   # bind list item rows and add relevant columns
   model_old_filtered <- dplyr::bind_rows(model_old[country_details]) %>%
     dplyr::filter(!is.na(value)) %>%
-    #dplyr::mutate(value = round(value, 2)) %>%
-    dplyr::mutate(old = 1)
+    dplyr::mutate(value = round(value, 5),
+                  percent = round(percent, 5)) %>%
+    rename(value.old = value,
+           percent.old = percent)
+  #dplyr::mutate(value = round(value, 2)) %>%
+  #dplyr::mutate(old = 1)
 
   model_new_filtered <- dplyr::bind_rows(model_new[country_details]) %>%
     dplyr::filter(!is.na(value)) %>%
-    #dplyr::mutate(value = round(value, 2)) %>%
-    dplyr::mutate(new = 1)
-
+    dplyr::mutate(value = round(value, 5),
+                  percent = round(percent, 5)) %>%
+    rename(value.new = value,
+           percent.new = percent)
+  #dplyr::mutate(value = round(value, 2)) %>%
+  #dplyr::mutate(old = 1)
   deltas  <-  dplyr::full_join(model_new_filtered, model_old_filtered) %>%
-    dplyr::filter(new != old |
-             is.na(new) | is.na(old)
-             )
+    dplyr::filter(value.new != value.old |
+                    percent.new != percent.old |
+                    is.na(value.new) |
+                    is.na(value.old) |
+                    is.na(percent.new) |
+                    is.na(percent.old)
+    )
 
   # add other columns
   if (!is.null(data_ancestors)) {
@@ -233,18 +244,18 @@ diffSnuximModels <- function(model_old, model_new,
                                          d2_session = d2_session)
   }
 
-   if (!is.null(data_psnu)) {
-     deltas <- dplyr::mutate(deltas,
-                             psnu = data_psnu,
-                             ou = purrr::map_chr(ancestors, purrr::pluck, 1, 3),
-                             snu1 = purrr::map_chr(ancestors, purrr::pluck, 1, 4, .default = NA_character_))
-   } else {
-     deltas <- dplyr::mutate(deltas,
-                             psnu = datimutils::getOrgUnits(psnu_uid,
-                                                            d2_session = d2_session),
-                             ou = purrr::map_chr(ancestors, purrr::pluck, 1, 3),
-                             snu1 = purrr::map_chr(ancestors, purrr::pluck, 1, 4, .default = NA_character_))
-   }
+  if (!is.null(data_psnu)) {
+    deltas <- dplyr::mutate(deltas,
+                            psnu = data_psnu,
+                            ou = purrr::map_chr(ancestors, purrr::pluck, 1, 3),
+                            snu1 = purrr::map_chr(ancestors, purrr::pluck, 1, 4, .default = NA_character_))
+  } else {
+    deltas <- dplyr::mutate(deltas,
+                            psnu = datimutils::getOrgUnits(psnu_uid,
+                                                           d2_session = d2_session),
+                            ou = purrr::map_chr(ancestors, purrr::pluck, 1, 3),
+                            snu1 = purrr::map_chr(ancestors, purrr::pluck, 1, 4, .default = NA_character_))
+  }
 
   return(deltas)
 }

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -162,8 +162,8 @@ test_that("Can compare psnuxim model data", {
   # new model data
   new_model <- list(
     XOivy2uDpMF = tribble(
-      ~indicator_code, ~psnu_uid, ~value,
-      "HTS_INDEX_COM.New.Neg.T", "bSwiBL5Y4SW", 4
+      ~indicator_code, ~psnu_uid, ~value, ~percent,
+      "HTS_INDEX_COM.New.Neg.T", "bSwiBL5Y4SW", 4, .45
     ),
     CDGPst7p3vc = tribble()
   )
@@ -171,21 +171,17 @@ test_that("Can compare psnuxim model data", {
   # old model that we "load" in
   old_model <- list(
     XOivy2uDpMF = tribble(
-      ~indicator_code, ~psnu_uid, ~value,
-      "HTS_INDEX_COM.New.Neg.T", "bSwiBL5Y4SW", 2
+      ~indicator_code, ~psnu_uid, ~value, ~ percent,
+      "HTS_INDEX_COM.New.Neg.T", "bSwiBL5Y4SW", 2, .45
     ),
     CDGPst7p3vc = tribble(),
     a71G4Gtcttv = tribble(
-      ~indicator_code, ~psnu_uid, ~value,
-      "CXCA_SCRN.T", "a3zBlSiF0wB", 16
+      ~indicator_code, ~psnu_uid, ~value, ~percent,
+      "CXCA_SCRN.T", "a3zBlSiF0wB", 16, .1
     )
   )
 
   ancestors_data <- list(
-    tribble(
-      ~name,
-      "Global", "Africa", "Angola"
-    ),
     tribble(
       ~name,
       "Global", "Africa", "Angola"
@@ -200,7 +196,7 @@ test_that("Can compare psnuxim model data", {
     data_psnu = c("_Military Angola"),
     full_diff = FALSE)
 
-  testthat::expect_equal(nrow(partial_deltas), 2)
+  testthat::expect_equal(nrow(partial_deltas), 1)
   rm(ancestors_data)
 
   # FULL DIFF, ALL COUNTRIES ----
@@ -211,11 +207,7 @@ test_that("Can compare psnuxim model data", {
     ),
     tribble(
       ~name,
-      "Global", "Africa", "Angola"
-    ),
-    tribble(
-      ~name,
-      "Global", "Africa", "Angola", "Matabeleland North"
+      "Global", "Africa", "Zimbabwe", "Matabeleland North"
     )
   )
 
@@ -223,8 +215,8 @@ test_that("Can compare psnuxim model data", {
      model_old = old_model,
      model_new = new_model,
      data_ancestors = ancestors_data,
-     data_psnu = c("_Military Angola", "_Military Angola", "Lupane"),
+     data_psnu = c("_Military Angola", "Lupane"),
      full_diff = TRUE)
-   testthat::expect_equal(nrow(total_diff), 3)
+   testthat::expect_equal(nrow(total_diff), 2)
 
 })


### PR DESCRIPTION
Due to differences in value and percent columns between model files, the join was sometimes splitting diffs into multiple rows instead of providing a one row summary.

Old

![image](https://user-images.githubusercontent.com/36417685/210380042-a4206c20-7844-4fdb-bed0-1dc9a3e555cf.png)

New
![image](https://user-images.githubusercontent.com/36417685/210382530-c4d08888-ac25-4fb2-aeb3-78dcc0fb937d.png)
